### PR TITLE
build.rs: emit position-independent code when compiling on ARM64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,12 @@ use std::env;
 use std::path;
 use std::process;
 
+#[cfg(target_arch = "aarch64")]
+const CFLAGS: &str = "-fPIC -pie";
+
+#[cfg(not(target_arch = "aarch64"))]
+const CFLAGS: &str = "";
+
 fn main() {
     let src_dir = path::PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
     let xdptools_dir = src_dir.join("xdp-tools");
@@ -12,6 +18,7 @@ fn main() {
     let bpf_headers_dir = libbpf_dir.join("root/usr/include");
 
     let status = process::Command::new("make")
+        .env("CFLAGS", CFLAGS)
         .arg("libxdp")
         .current_dir(&xdptools_dir)
         .status()


### PR DESCRIPTION
Currently, this crate cannot be used in ARM64 projects: While the crate itself compiles just fine, a binary project depending on libxdp_sys fails to compile:

```
/usr/bin/ld: /home/.../target/debug/deps/liblibxdp_sys-7ecba993bf090f40.rlib(libxdp.o): relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `stderr@@GLIBC_2.17' which may bind externally can not be used when making a shared object; recompile with -fPIC 
```

This PR adds the CFLAGS `-fPIC -pie` when invoking `make` for `libxdp`, which fixes the issue (well, at least for me).